### PR TITLE
Restrict opt-in to certain user roles

### DIFF
--- a/src/Admin/Customizer/OptinForm/CustomizerControls.php
+++ b/src/Admin/Customizer/OptinForm/CustomizerControls.php
@@ -1434,8 +1434,22 @@ class CustomizerControls
                             'show_all'           => __('Show to all visitors and users', 'mailoptin'),
                             'show_logged_in'     => __('Show to only logged-in users', 'mailoptin'),
                             'show_non_logged_in' => __('Show to only users not logged-in', 'mailoptin'),
+                            'show_to_roles'      => __('Show to specific user roles', 'mailoptin'),
                         ],
                         'priority'    => 10,
+                    )
+                ),
+                'show_to_roles'             => new WP_Customize_Chosen_Select_Control(
+                    $this->wp_customize,
+                    $this->option_prefix . '[show_to_roles]',
+                    apply_filters('mo_optin_form_customizer_show_to_roles_args', array(
+                            'label'         => __('Restrict to User Role'),
+                            'section'       => $this->customizerClassInstance->user_targeting_display_rule_section_id,
+                            'settings'      => $this->option_prefix . '[show_to_roles]',
+                            'description'   => __('The opt-in form will only be shown to users with any of the roles you select here.', 'mailoptin'),
+                            'choices'       => ControlsHelpers::get_roles(),
+                            'priority'      => 11
+                        )
                     )
                 )
             ),

--- a/src/Admin/Customizer/OptinForm/CustomizerSettings.php
+++ b/src/Admin/Customizer/OptinForm/CustomizerSettings.php
@@ -656,6 +656,11 @@ class CustomizerSettings extends AbstractCustomizer
                     'type'      => 'option',
                     'transport' => 'postMessage',
                 ),
+                'show_to_roles'                   => array(
+                    'default'   => apply_filters('mo_optin_form_show_to_roles', ''),
+                    'type'      => 'option',
+                    'transport' => 'postMessage',
+                ),
                 'after_conversion_notice'         => array(
                     'default'   => apply_filters('mo_optin_form_after_conversion_notice', false),
                     'type'      => 'option',

--- a/src/OptinForms/UserTargetingRuleTrait.php
+++ b/src/OptinForms/UserTargetingRuleTrait.php
@@ -15,6 +15,19 @@ trait UserTargetingRuleTrait
     public function user_targeting_rule_checker($id)
     {
         switch (OCR::get_customizer_value($id, 'who_see_optin')) {
+            case 'show_to_roles':
+            
+                //If user is logged out abort early
+                if (!is_user_logged_in()) return false;
+
+                //Fetch roles and abort if none is specified
+                $roles = OCR::get_customizer_value($id, 'show_to_roles');
+                if (empty($roles) || !is_array($roles)) return false;
+
+                //Check if user has any of the allowed user roles
+                $user = wp_get_current_user();
+                return 0 !== count(array_intersect($roles, (array) $user->roles));
+                break;
             case 'show_logged_in':
                 if (!is_user_logged_in()) return false;
                 break;

--- a/src/assets/js/customizer-controls/contextual-customizer-controls.js
+++ b/src/assets/js/customizer-controls/contextual-customizer-controls.js
@@ -322,6 +322,10 @@
                 .toggle(!this.checked)
         }).change();
 
+        $('select[data-customize-setting-link*=who_see_optin]').change(function () {
+            $('li[id*=show_to_roles]').toggle($(this).val() == 'show_to_roles');
+        }).change();
+
         // handles click to select on input readonly fields
         $('.mo-click-select').click(function () {
             this.select();


### PR DESCRIPTION
@collizo4sky this PR makes it possible to restrict opt-in forms to users with specific user roles. For example, might be useful when a store owner wants to remind existing customers to subscribe to their email list.