### PR TITLE
Clean vendor before re-install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ branches:
 
 cache:
   directories:
-    - vendor
     - $HOME/.composer/cache
 
 matrix:


### PR DESCRIPTION
Caching packages using $HOME/.composer/cache is enough to optimize the Travis build but installation of vendor directory should be re-created from scratch on test (and deploy) as other sources.